### PR TITLE
Add generate-tags action implementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 KoalaOps
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,39 @@
-# generate-tags
+# Generate Tags
 
-GitHub Action - Coming soon
+**Internal Action** - Generates image tags for matrix builds in monorepo workflows.
 
-This repository will contain the generate-tags action.
+## Purpose
+
+This action is used internally for monorepo matrix builds to generate appropriate tags for each service. Not intended for direct use.
+
+## Usage
+
+```yaml
+# Internal use in matrix workflows
+- uses: KoalaOps/generate-tags@v1
+  with:
+    services_config_path: services.json
+    tag_format: branch-date-counter
+    branch: main
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `services_config_path` | Path to services.json file | ❌ | `services.json` |
+| `service_name` | Single service name (when not using services.json) | ❌ | - |
+| `tag_format` | Tag format: branch-date, branch-date-counter, semver, custom | ❌ | `branch-date-counter` |
+| `branch` | Branch name for tag generation | ❌ | `${{ github.ref_name }}` |
+| `custom_base_tag` | Custom base tag (used when tag_format is custom) | ❌ | - |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `tags` | JSON object mapping service names to tags |
+| `base_tag` | Base tag used for all services |
+
+## Note
+
+This is an internal action for monorepo matrix builds. Use `determine-image-tag` action for standard tag generation.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,103 @@
+name: 'Generate Service Tags'
+description: 'Generate tags for services based on services.json or single service'
+
+inputs:
+  services_config_path:
+    description: 'Path to services.json file'
+    required: false
+    default: 'services.json'
+  service_name:
+    description: 'Single service name (when not using services.json)'
+    required: false
+  tag_format:
+    description: 'Tag format: branch-date, branch-date-counter, semver, custom'
+    required: false
+    default: 'branch-date-counter'
+  branch:
+    description: 'Branch name for tag generation'
+    required: false
+    default: ${{ github.ref_name }}
+  custom_base_tag:
+    description: 'Custom base tag (used when tag_format is custom)'
+    required: false
+
+outputs:
+  tags:
+    description: 'JSON object mapping service names to tags'
+    value: ${{ steps.generate.outputs.tags }}
+  base_tag:
+    description: 'Base tag used for all services'
+    value: ${{ steps.generate.outputs.base_tag }}
+
+runs:
+  using: composite
+  steps:
+    - name: Generate tags
+      id: generate
+      shell: bash
+      run: |
+        # Generate base tag based on format
+        case "${{ inputs.tag_format }}" in
+          "branch-date")
+            BASE_TAG="${{ inputs.branch }}-$(date +%Y%m%d-%H%M%S)"
+            ;;
+          "branch-date-counter")
+            BASE_TAG="${{ inputs.branch }}-$(date +%Y%m%d-%H%M%S)"
+            ;;
+          "semver")
+            # Would integrate with git tags for proper semver
+            BASE_TAG="v$(date +%Y.%m.%d)"
+            ;;
+          "custom")
+            BASE_TAG="${{ inputs.custom_base_tag }}"
+            ;;
+          *)
+            BASE_TAG="$(date +%Y%m%d-%H%M%S)"
+            ;;
+        esac
+        
+        # Clean branch name for use in tags
+        BASE_TAG=$(echo "$BASE_TAG" | sed 's/refs\/heads\///g' | sed 's/\//-/g')
+        
+        echo "base_tag=$BASE_TAG" >> $GITHUB_OUTPUT
+        
+        # Check if services.json exists
+        if [ -f "${{ inputs.services_config_path }}" ]; then
+          echo "Found services.json, generating tags for multiple services"
+          
+          SERVICES_JSON=$(cat "${{ inputs.services_config_path }}")
+          TAGS_JSON="{}"
+          COUNTER=0
+          
+          for service in $(echo "$SERVICES_JSON" | jq -c '.services[]'); do
+            SERVICE_NAME=$(echo "$service" | jq -r '.name')
+            
+            # Add counter for multi-service repos if using counter format
+            if [ "${{ inputs.tag_format }}" == "branch-date-counter" ]; then
+              SERVICE_TAG="${BASE_TAG}-${COUNTER}"
+            else
+              SERVICE_TAG="${BASE_TAG}"
+            fi
+            
+            TAGS_JSON=$(echo "$TAGS_JSON" | jq --arg name "$SERVICE_NAME" --arg tag "$SERVICE_TAG" '.[$name] = $tag')
+            COUNTER=$((COUNTER + 1))
+          done
+          
+          echo "tags=$TAGS_JSON" >> $GITHUB_OUTPUT
+          
+        else
+          echo "No services.json found, generating single service tag"
+          
+          SERVICE_NAME="${{ inputs.service_name }}"
+          if [ -z "$SERVICE_NAME" ]; then
+            SERVICE_NAME="app"  # Default service name
+          fi
+          
+          # Single service doesn't need counter
+          TAGS_JSON=$(jq -n --arg name "$SERVICE_NAME" --arg tag "$BASE_TAG" '{($name): $tag}')
+          
+          echo "tags=$TAGS_JSON" >> $GITHUB_OUTPUT
+        fi
+        
+        echo "Generated tags:"
+        echo "$TAGS_JSON" | jq .


### PR DESCRIPTION
## Summary
This PR adds the initial implementation of the generate-tags action.

## Changes
- Added `action.yml` with the full action implementation
- Added comprehensive README with usage examples and documentation
- Added MIT LICENSE